### PR TITLE
feat(attachments): useAttachments data-ops core (Phase 1a)

### DIFF
--- a/src/__tests__/attachmentInheritance.test.js
+++ b/src/__tests__/attachmentInheritance.test.js
@@ -18,7 +18,7 @@ describe('computeEffectiveAttachments', () => {
   ]
 
   it('direct node attachments remain on their node, unflagged as inherited', () => {
-    const atts = [{ id: 'a1', node_id: 'vm-a', scope: 'node', stage: 'run' }]
+    const atts = [{ id: 'a1', target_node: 'vm-a', scope: 'node', stage: 'run' }]
     const out = computeEffectiveAttachments(nodes, atts)
     expect(out.get('vm-a')).toHaveLength(1)
     expect(out.get('vm-a')[0].id).toBe('a1')
@@ -27,7 +27,7 @@ describe('computeEffectiveAttachments', () => {
   })
 
   it('group_inherited attachments propagate to all descendants (including nested group descendants)', () => {
-    const atts = [{ id: 'inh', node_id: 'g1', scope: 'group_inherited', stage: 'preflight' }]
+    const atts = [{ id: 'inh', target_node: 'g1', scope: 'group_inherited', stage: 'preflight' }]
     const out = computeEffectiveAttachments(nodes, atts)
     // Group owns its own copy (non-inherited — it's the source row)
     expect(out.get('g1')).toHaveLength(1)
@@ -46,8 +46,8 @@ describe('computeEffectiveAttachments', () => {
 
   it('merges direct + inherited attachments on the same node', () => {
     const atts = [
-      { id: 'direct', node_id: 'vm-a', scope: 'node', stage: 'post' },
-      { id: 'inh', node_id: 'g1', scope: 'group_inherited', stage: 'pre' },
+      { id: 'direct', target_node: 'vm-a', scope: 'node', stage: 'post' },
+      { id: 'inh', target_node: 'g1', scope: 'group_inherited', stage: 'pre' },
     ]
     const out = computeEffectiveAttachments(nodes, atts)
     const list = out.get('vm-a')
@@ -58,7 +58,7 @@ describe('computeEffectiveAttachments', () => {
   })
 
   it('does not mutate the source attachments array', () => {
-    const atts = [{ id: 'inh', node_id: 'g1', scope: 'group_inherited' }]
+    const atts = [{ id: 'inh', target_node: 'g1', scope: 'group_inherited' }]
     const snapshot = JSON.stringify(atts)
     computeEffectiveAttachments(nodes, atts)
     expect(JSON.stringify(atts)).toBe(snapshot)
@@ -67,9 +67,9 @@ describe('computeEffectiveAttachments', () => {
 
 describe('applyBulkAttachmentEdit', () => {
   const atts = [
-    { id: 'a1', node_id: 'vm-a', stage: 'pre', order: 0 },
-    { id: 'a2', node_id: 'vm-b', stage: 'pre', order: 1 },
-    { id: 'a3', node_id: 'g1', scope: 'node' },
+    { id: 'a1', target_node: 'vm-a', stage: 'pre', order_in_stage: 0 },
+    { id: 'a2', target_node: 'vm-b', stage: 'pre', order_in_stage: 1 },
+    { id: 'a3', target_node: 'g1', scope: 'node' },
   ]
 
   it('sets stage on selected rows only', () => {

--- a/src/__tests__/composeAttachments.test.js
+++ b/src/__tests__/composeAttachments.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { compose } from '@/overlay/compose'
+
+function baseDoc() {
+  return {
+    schema_version: '1.0',
+    kind: 'lab',
+    name: 'base',
+    nodes: [{ id: 'vm-a', kind: 'vm' }],
+  }
+}
+
+describe('compose — UI attachment shape reaches the right node', () => {
+  it('appends a canonical attachment (target_node + source) onto its node, dropping target_node', () => {
+    const overlay = {
+      schema_version: '1.0',
+      source_url: 'x',
+      source_sha: 'y',
+      attachments_added: [
+        {
+          id: 'att1',
+          target_node: 'vm-a',
+          stage: 'main',
+          order_in_stage: 0,
+          source: { kind: 'catalog_role', ref: 'src-a:roles/wazuh' },
+        },
+      ],
+    }
+    const eff = compose(baseDoc(), overlay)
+    const node = eff.nodes.find((n) => n.id === 'vm-a')
+    expect(node.attachments).toHaveLength(1)
+    const att = node.attachments[0]
+    expect(att.source.kind).toBe('catalog_role')
+    expect(att.stage).toBe('main')
+    expect(att.order_in_stage).toBe(0)
+    expect(att.target_node).toBeUndefined() // compose strips the routing key
+  })
+
+  it('drops a legacy attachment that uses node_id instead of target_node (guards the drift)', () => {
+    const overlay = {
+      schema_version: '1.0',
+      source_url: 'x',
+      source_sha: 'y',
+      attachments_added: [{ id: 'legacy', node_id: 'vm-a', stage: 'main' }],
+    }
+    const eff = compose(baseDoc(), overlay)
+    expect(eff.nodes.find((n) => n.id === 'vm-a').attachments).toBeUndefined()
+  })
+})

--- a/src/__tests__/normalizeAttachment.test.js
+++ b/src/__tests__/normalizeAttachment.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeAttachment } from '../composables/useInfraBuilder'
+
+describe('normalizeAttachment — legacy → canonical attachment shape', () => {
+  it('maps node_id → target_node and order → order_in_stage, dropping the legacy keys', () => {
+    const out = normalizeAttachment({ id: 'a', node_id: 'vm-a', order: 2, stage: 'pre' })
+    expect(out.target_node).toBe('vm-a')
+    expect(out.order_in_stage).toBe(2)
+    expect(out.node_id).toBeUndefined()
+    expect(out.order).toBeUndefined()
+    expect(out.stage).toBe('pre')
+  })
+
+  it('preserves a literal order of 0', () => {
+    expect(normalizeAttachment({ id: 'a', node_id: 'x', order: 0 }).order_in_stage).toBe(0)
+  })
+
+  it('is idempotent on already-canonical rows', () => {
+    const canon = { id: 'a', target_node: 'vm-a', order_in_stage: 1, source: { kind: 'inline_yaml' } }
+    expect(normalizeAttachment(canon)).toEqual(canon)
+  })
+
+  it('prefers an existing target_node over node_id when both are present', () => {
+    const out = normalizeAttachment({ id: 'a', target_node: 'canon', node_id: 'legacy' })
+    expect(out.target_node).toBe('canon')
+    expect(out.node_id).toBeUndefined()
+  })
+
+  it('passes non-object input through unchanged', () => {
+    expect(normalizeAttachment(null)).toBeNull()
+    expect(normalizeAttachment(undefined)).toBeUndefined()
+  })
+})

--- a/src/__tests__/useAttachments.test.js
+++ b/src/__tests__/useAttachments.test.js
@@ -88,3 +88,71 @@ describe('attachment mutators (pure, immutable)', () => {
     expect(removeAttachment(undefined, 'a1')).toEqual([])
   })
 })
+
+import { validateAttachment, normalizeAttachments } from '../composables/useAttachments'
+
+const codes = (a) => validateAttachment(a).map((p) => p.code)
+
+describe('validateAttachment — per-kind completeness rules', () => {
+  it('flags a missing target_node', () => {
+    const a = { id: 'x', source: { kind: 'inline_yaml', content_ref: 'attachments/x.yaml' } }
+    expect(codes(a)).toContain('attachment.target_node.missing')
+  })
+
+  it('flags a missing source kind', () => {
+    expect(codes({ id: 'x', target_node: 'vm-a' })).toContain('attachment.source.missing')
+  })
+
+  it('catalog kinds require a source.ref', () => {
+    expect(codes({ id: 'x', target_node: 'vm-a', source: { kind: 'catalog_role' } })).toContain(
+      'attachment.catalog.ref.missing',
+    )
+    expect(
+      codes({ id: 'x', target_node: 'vm-a', source: { kind: 'catalog_container', ref: 'src:c/x' } }),
+    ).toEqual([])
+  })
+
+  it('catalog kinds do NOT require a sha (sha is null from the backend today)', () => {
+    const a = { id: 'x', target_node: 'vm-a', source: { kind: 'catalog_role', ref: 'src:roles/x' } }
+    expect(codes(a)).not.toContain('attachment.git.sha.missing')
+    expect(codes(a)).toEqual([])
+  })
+
+  it('inline_yaml and file_upload require content_ref', () => {
+    expect(codes({ id: 'x', target_node: 'vm-a', source: { kind: 'inline_yaml' } })).toContain(
+      'attachment.content.missing',
+    )
+    expect(codes({ id: 'x', target_node: 'vm-a', source: { kind: 'file_upload' } })).toContain(
+      'attachment.content.missing',
+    )
+  })
+
+  it('external_git requires a url and a pinned sha', () => {
+    expect(codes({ id: 'x', target_node: 'vm-a', source: { kind: 'external_git' } })).toEqual(
+      expect.arrayContaining(['attachment.git.url.missing', 'attachment.git.sha.missing']),
+    )
+  })
+
+  it('external_git rejects a malformed url', () => {
+    const a = { id: 'x', target_node: 'vm-a', source: { kind: 'external_git', url: 'not a url', sha: 'abc' } }
+    expect(codes(a)).toContain('attachment.git.url.invalid')
+  })
+
+  it('external_git accepts https and git@ ssh urls with a sha', () => {
+    expect(
+      codes({ id: 'x', target_node: 'vm-a', source: { kind: 'external_git', url: 'https://gh/o/r.git', sha: 'abc' } }),
+    ).toEqual([])
+    expect(
+      codes({ id: 'x', target_node: 'vm-a', source: { kind: 'external_git', url: 'git@gh:o/r.git', sha: 'abc' } }),
+    ).toEqual([])
+  })
+})
+
+describe('normalizeAttachments', () => {
+  it('maps legacy rows to canonical and tolerates empty input', () => {
+    const out = normalizeAttachments([{ id: 'a', node_id: 'vm-a', order: 1 }])
+    expect(out[0]).toMatchObject({ target_node: 'vm-a', order_in_stage: 1 })
+    expect(out[0].node_id).toBeUndefined()
+    expect(normalizeAttachments(null)).toEqual([])
+  })
+})

--- a/src/__tests__/useAttachments.test.js
+++ b/src/__tests__/useAttachments.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { createAttachment } from '../composables/useAttachments'
+
+describe('createAttachment', () => {
+  it('builds a canonical attachment with sane defaults', () => {
+    const a = createAttachment('inline_yaml', 'vm-a', { id: 'fixed-id' })
+    expect(a).toEqual({
+      id: 'fixed-id',
+      target_node: 'vm-a',
+      source: { kind: 'inline_yaml' },
+      stage: 'main',
+      scope: 'node',
+    })
+  })
+
+  it('honors an explicit stage and title', () => {
+    const a = createAttachment('catalog_role', 'vm-a', { id: 'x', stage: 'preflight', title: 'Wazuh' })
+    expect(a.stage).toBe('preflight')
+    expect(a.title).toBe('Wazuh')
+  })
+
+  it('generates a unique id when none is provided', () => {
+    const a = createAttachment('external_git', 'vm-a')
+    const b = createAttachment('external_git', 'vm-a')
+    expect(typeof a.id).toBe('string')
+    expect(a.id.length).toBeGreaterThan(0)
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it('omits title when not provided', () => {
+    const a = createAttachment('file_upload', 'vm-a', { id: 'x' })
+    expect('title' in a).toBe(false)
+  })
+})

--- a/src/__tests__/useAttachments.test.js
+++ b/src/__tests__/useAttachments.test.js
@@ -32,3 +32,59 @@ describe('createAttachment', () => {
     expect('title' in a).toBe(false)
   })
 })
+
+import {
+  updateAttachment,
+  removeAttachment,
+  setAttachmentScope,
+  setAttachmentOrder,
+  setAttachmentSource,
+} from '../composables/useAttachments'
+
+describe('attachment mutators (pure, immutable)', () => {
+  const list = () => [
+    { id: 'a1', target_node: 'vm-a', source: { kind: 'inline_yaml' }, stage: 'main', scope: 'node' },
+    { id: 'a2', target_node: 'vm-b', source: { kind: 'catalog_role', ref: 'src:roles/x' }, stage: 'main', scope: 'node' },
+  ]
+
+  it('updateAttachment shallow-merges a patch onto the matching row only', () => {
+    const out = updateAttachment(list(), 'a1', { stage: 'post', title: 'T' })
+    expect(out.find((a) => a.id === 'a1')).toMatchObject({ stage: 'post', title: 'T' })
+    expect(out.find((a) => a.id === 'a2').stage).toBe('main')
+  })
+
+  it('updateAttachment does not mutate the input array or rows', () => {
+    const input = list()
+    const snapshot = JSON.stringify(input)
+    updateAttachment(input, 'a1', { stage: 'post' })
+    expect(JSON.stringify(input)).toBe(snapshot)
+  })
+
+  it('removeAttachment drops the matching row', () => {
+    expect(removeAttachment(list(), 'a1').map((a) => a.id)).toEqual(['a2'])
+  })
+
+  it('setAttachmentScope sets scope on the matching row', () => {
+    expect(setAttachmentScope(list(), 'a1', 'group_inherited').find((a) => a.id === 'a1').scope).toBe(
+      'group_inherited',
+    )
+  })
+
+  it('setAttachmentOrder writes order_in_stage (canonical field)', () => {
+    expect(setAttachmentOrder(list(), 'a2', 3).find((a) => a.id === 'a2').order_in_stage).toBe(3)
+  })
+
+  it('setAttachmentSource merges into source without dropping existing source fields', () => {
+    const out = setAttachmentSource(list(), 'a2', { sha: 'abc123' })
+    expect(out.find((a) => a.id === 'a2').source).toEqual({
+      kind: 'catalog_role',
+      ref: 'src:roles/x',
+      sha: 'abc123',
+    })
+  })
+
+  it('mutators tolerate null/undefined input', () => {
+    expect(updateAttachment(null, 'a1', { stage: 'x' })).toEqual([])
+    expect(removeAttachment(undefined, 'a1')).toEqual([])
+  })
+})

--- a/src/components/project/AttachmentManager.vue
+++ b/src/components/project/AttachmentManager.vue
@@ -50,7 +50,7 @@ const selectionIntersectsGroup = computed(() => {
   )
   for (const a of props.attachments) {
     if (!selected.value.has(a.id)) continue
-    if (a.node_id && groupIds.has(a.node_id)) return true
+    if (a.target_node && groupIds.has(a.target_node)) return true
   }
   return false
 })
@@ -178,9 +178,9 @@ function applyNodeScoped() {
             />
           </td>
           <td class="font-mono text-xs">{{ a.id }}</td>
-          <td class="font-mono text-xs">{{ a.node_id }}</td>
+          <td class="font-mono text-xs">{{ a.target_node }}</td>
           <td>{{ a.stage || '—' }}</td>
-          <td>{{ a.order ?? '—' }}</td>
+          <td>{{ a.order_in_stage ?? '—' }}</td>
           <td>
             <span class="badge badge-xs" :class="a.scope === 'group_inherited' ? 'badge-accent' : 'badge-ghost'">
               {{ a.scope || 'node' }}

--- a/src/composables/useAttachments.ts
+++ b/src/composables/useAttachments.ts
@@ -8,6 +8,8 @@
  */
 import type {
   Attachment,
+  AttachmentScope,
+  AttachmentSource,
   AttachmentSourceKind,
 } from '@/types/range42-schema'
 
@@ -34,4 +36,50 @@ export function createAttachment(
   }
   if (opts.title) att.title = opts.title
   return att
+}
+
+/** Shallow-merge `patch` onto the attachment with `id`. Returns a new array. */
+export function updateAttachment(
+  attachments: Attachment[] | null | undefined,
+  id: string,
+  patch: Partial<Attachment>,
+): Attachment[] {
+  return (attachments ?? []).map((a) => (a.id === id ? { ...a, ...patch } : a))
+}
+
+/** Remove the attachment with `id`. Returns a new array. */
+export function removeAttachment(
+  attachments: Attachment[] | null | undefined,
+  id: string,
+): Attachment[] {
+  return (attachments ?? []).filter((a) => a.id !== id)
+}
+
+/** Set `scope` on the attachment with `id`. */
+export function setAttachmentScope(
+  attachments: Attachment[] | null | undefined,
+  id: string,
+  scope: AttachmentScope,
+): Attachment[] {
+  return updateAttachment(attachments, id, { scope })
+}
+
+/** Set the canonical `order_in_stage` on the attachment with `id`. */
+export function setAttachmentOrder(
+  attachments: Attachment[] | null | undefined,
+  id: string,
+  order: number,
+): Attachment[] {
+  return updateAttachment(attachments, id, { order_in_stage: order })
+}
+
+/** Merge `sourcePatch` into the attachment's `source` (preserves other source fields). */
+export function setAttachmentSource(
+  attachments: Attachment[] | null | undefined,
+  id: string,
+  sourcePatch: Partial<AttachmentSource>,
+): Attachment[] {
+  return (attachments ?? []).map((a) =>
+    a.id === id ? { ...a, source: { ...a.source, ...sourcePatch } } : a,
+  )
 }

--- a/src/composables/useAttachments.ts
+++ b/src/composables/useAttachments.ts
@@ -12,6 +12,7 @@ import type {
   AttachmentSource,
   AttachmentSourceKind,
 } from '@/types/range42-schema'
+import { normalizeAttachment } from '@/composables/useInfraBuilder'
 
 const DEFAULT_STAGE = 'main'
 
@@ -82,4 +83,92 @@ export function setAttachmentSource(
   return (attachments ?? []).map((a) =>
     a.id === id ? { ...a, source: { ...a.source, ...sourcePatch } } : a,
   )
+}
+
+export interface AttachmentProblem {
+  field: string
+  code: string
+  message: string
+}
+
+function isValidGitUrl(url: string): boolean {
+  return /^https:\/\/\S+$/.test(url) || /^git@[^:\s]+:\S+$/.test(url) || /^ssh:\/\/\S+$/.test(url)
+}
+
+/**
+ * Return the completeness problems for an attachment (empty = valid/deployable).
+ * Per-kind rules; catalog `sha` is intentionally NOT required (the backend
+ * emits null shas today — see the attachments spec).
+ */
+export function validateAttachment(a: Attachment | null | undefined): AttachmentProblem[] {
+  const problems: AttachmentProblem[] = []
+  if (!a || typeof a !== 'object') return problems
+  if (!a.target_node) {
+    problems.push({
+      field: 'target_node',
+      code: 'attachment.target_node.missing',
+      message: 'Attachment has no target node',
+    })
+  }
+  const src = a.source
+  if (!src || !src.kind) {
+    problems.push({
+      field: 'source.kind',
+      code: 'attachment.source.missing',
+      message: 'Attachment has no source kind',
+    })
+    return problems
+  }
+  switch (src.kind) {
+    case 'catalog_role':
+    case 'catalog_container':
+      if (!src.ref) {
+        problems.push({
+          field: 'source.ref',
+          code: 'attachment.catalog.ref.missing',
+          message: 'Catalog attachment has no source reference',
+        })
+      }
+      break
+    case 'inline_yaml':
+    case 'file_upload':
+      if (!src.content_ref) {
+        problems.push({
+          field: 'source.content_ref',
+          code: 'attachment.content.missing',
+          message: 'Attachment has no content',
+        })
+      }
+      break
+    case 'external_git':
+      if (!src.url) {
+        problems.push({
+          field: 'source.url',
+          code: 'attachment.git.url.missing',
+          message: 'External git attachment has no URL',
+        })
+      } else if (!isValidGitUrl(src.url)) {
+        problems.push({
+          field: 'source.url',
+          code: 'attachment.git.url.invalid',
+          message: 'External git URL must be https:// or git@host:path',
+        })
+      }
+      if (!src.sha) {
+        problems.push({
+          field: 'source.sha',
+          code: 'attachment.git.sha.missing',
+          message: 'External git attachment must be pinned to a commit sha',
+        })
+      }
+      break
+  }
+  return problems
+}
+
+/** Upgrade a list of (possibly legacy) attachment rows to canonical shape. */
+export function normalizeAttachments(
+  attachments: Attachment[] | null | undefined,
+): Attachment[] {
+  return (attachments ?? []).map(normalizeAttachment)
 }

--- a/src/composables/useAttachments.ts
+++ b/src/composables/useAttachments.ts
@@ -1,0 +1,37 @@
+/**
+ * useAttachments — pure data operations over the canonical Attachment shape.
+ *
+ * No DOM, no reactivity, no network: every function takes plain data and
+ * returns plain data, so the attachment editor and host components can compose
+ * them while staying fully unit-testable. Content-file storage for
+ * inline_yaml/file_upload is intentionally NOT handled here (Phase 1b).
+ */
+import type {
+  Attachment,
+  AttachmentSourceKind,
+} from '@/types/range42-schema'
+
+const DEFAULT_STAGE = 'main'
+
+export interface CreateAttachmentOptions {
+  id?: string
+  stage?: string
+  title?: string
+}
+
+/** Build a new canonical attachment for `targetNode` with sane defaults. */
+export function createAttachment(
+  kind: AttachmentSourceKind,
+  targetNode: string,
+  opts: CreateAttachmentOptions = {},
+): Attachment {
+  const att: Attachment = {
+    id: opts.id ?? crypto.randomUUID(),
+    target_node: targetNode,
+    source: { kind },
+    stage: opts.stage ?? DEFAULT_STAGE,
+    scope: 'node',
+  }
+  if (opts.title) att.title = opts.title
+  return att
+}

--- a/src/composables/useInfraBuilder.js
+++ b/src/composables/useInfraBuilder.js
@@ -33,6 +33,26 @@ export function getTeamScopeAncestorId(node, allNodes) {
 }
 
 /**
+ * Upgrade a persisted attachment row to the canonical schema shape:
+ *   node_id → target_node, order → order_in_stage.
+ * Pure and idempotent — canonical rows pass through unchanged, and legacy keys
+ * are always removed so downstream code only ever sees canonical names.
+ */
+export function normalizeAttachment(raw) {
+  if (!raw || typeof raw !== 'object') return raw
+  const a = { ...raw }
+  if (a.target_node === undefined && a.node_id !== undefined) {
+    a.target_node = a.node_id
+  }
+  delete a.node_id
+  if (a.order_in_stage === undefined && a.order !== undefined) {
+    a.order_in_stage = a.order
+  }
+  delete a.order
+  return a
+}
+
+/**
  * Compute the effective attachments for each node: direct attachments on the
  * node itself PLUS any attachments with `scope: 'group_inherited'` defined on
  * a group ancestor (team_scope or topology_group). Inherited attachments are
@@ -438,5 +458,6 @@ export function useInfraBuilder() {
     getTeamScopeAncestorId,
     computeEffectiveAttachments,
     applyBulkAttachmentEdit,
+    normalizeAttachment,
   }
 }

--- a/src/composables/useInfraBuilder.js
+++ b/src/composables/useInfraBuilder.js
@@ -61,7 +61,7 @@ export function normalizeAttachment(raw) {
  * duplicate records.
  *
  * Pure function — callers pass the full nodes list + a flat attachments list:
- *   attachments: [{ id, node_id, scope?: 'node' | 'group_inherited', ... }]
+ *   attachments: [{ id, target_node, scope?: 'node' | 'group_inherited', ... }]
  *
  * Returns: Map<nodeId, Attachment[]>
  */
@@ -73,19 +73,19 @@ export function computeEffectiveAttachments(allNodes, attachments) {
   // 1) Direct attachments go on their owning node unchanged.
   const groupInherited = []
   for (const a of attachments || []) {
-    if (!a?.node_id) continue
+    if (!a?.target_node) continue
     if (a.scope === 'group_inherited') {
       groupInherited.push(a)
       continue
     }
-    if (!byNode.has(a.node_id)) byNode.set(a.node_id, [])
-    byNode.get(a.node_id).push({ ...a, inherited: false })
+    if (!byNode.has(a.target_node)) byNode.set(a.target_node, [])
+    byNode.get(a.target_node).push({ ...a, inherited: false })
   }
 
   // 2) Inherited attachments: each group_inherited attachment on a group node
   //    propagates to all descendant nodes (leaf + nested groups) as a copy.
   for (const a of groupInherited) {
-    const group = byId.get(a.node_id)
+    const group = byId.get(a.target_node)
     if (!group) continue
     // Also attach to the group itself so Config tab shows it on the group row.
     if (!byNode.has(group.id)) byNode.set(group.id, [])
@@ -128,7 +128,7 @@ export function applyBulkAttachmentEdit(attachments, selectedIds, edit) {
     if (!selected.has(a.id)) return a
     const next = { ...a }
     if (edit?.setStage !== undefined) next.stage = edit.setStage
-    if (edit?.setOrder !== undefined) next.order = Number(edit.setOrder) || 0
+    if (edit?.setOrder !== undefined) next.order_in_stage = Number(edit.setOrder) || 0
     if (edit?.setScope !== undefined) next.scope = edit.setScope
     if (edit?.addVars) {
       next.vars = { ...(a.vars || {}), ...edit.addVars }

--- a/src/views/ProjectEditor.vue
+++ b/src/views/ProjectEditor.vue
@@ -44,7 +44,7 @@ import { useNetworkZones } from '../composables/useNetworkZones'
 import { useCanvasLiveStatus } from '../composables/useCanvasLiveStatus'
 import { useDeploymentStore } from '../stores/deploymentStore.ts'
 import NetworkZoneOverlay from '../components/NetworkZoneOverlay.vue'
-import { useInfraBuilder, computeDockerTetherEdges, nextKeyboardSelection } from '../composables/useInfraBuilder'
+import { useInfraBuilder, computeDockerTetherEdges, nextKeyboardSelection, normalizeAttachment } from '../composables/useInfraBuilder'
 import { useDeployment } from '../composables/useDeployment'
 import { useApiConfig } from '../composables/useApiConfig'
 import { useWebSocketStatus } from '../composables/useWebSocketStatus'
@@ -128,7 +128,9 @@ const dockerTetherEdges = computed(() => computeDockerTetherEdges(liveNodes.valu
 const renderedEdges = computed(() => [...(edges.value || []), ...dockerTetherEdges.value])
 
 // Problems panel — reactive over the live canvas graph.
-const attachmentsRef = computed(() => currentProject.value?.attachments || [])
+const attachmentsRef = computed(() =>
+  (currentProject.value?.attachments || []).map(normalizeAttachment),
+)
 const { problems: problemList } = useProblems(liveNodes, liveEdges, attachmentsRef)
 const showProblemsPanel = ref(true)
 


### PR DESCRIPTION
Adds a pure, fully-tested useAttachments module: createAttachment, the update/remove/scope/order/source mutators, validateAttachment (per-kind completeness rules), and a normalizeAttachments convenience. No DOM, no content-file I/O — the logic core the attachment editor (Phase 1b) and host components (Phase 1c) build on.

Depends on the Phase 0 normalizeAttachment (PR #76); this branch is stacked on it, so merge #76 first.